### PR TITLE
タグを表現できるようにする

### DIFF
--- a/backend/app/models/memo.rb
+++ b/backend/app/models/memo.rb
@@ -11,6 +11,11 @@
 #  updated_at            :datetime         not null
 #
 class Memo < ApplicationRecord
-  validates :title, :content, presence: true
   has_many :comments, dependent: :destroy
+  has_many :memo_tags, dependent: :destroy
+  has_many :tags, through: :memo_tags
+
+  validates :title, presence: true
+  validates :title, length: { maximum: 30 }
+  validates :content, presence: true
 end

--- a/backend/app/models/memo_tag.rb
+++ b/backend/app/models/memo_tag.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: memo_tags
+#
+#  id              :bigint           not null, primary key
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  memo_id(メモID) :bigint           not null
+#  tag_id(タグID)  :bigint           not null
+#
+# Indexes
+#
+#  index_memo_tags_on_memo_id                    (memo_id)
+#  index_memo_tags_on_tag_id                     (tag_id)
+#  unique_index_memo_id_and_tag_id_on_memo_tags  (memo_id,tag_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_memo_id_on_memo_tags  (memo_id => memos.id)
+#  fk_tag_id_on_memo_tags   (tag_id => tags.id)
+#
+class MemoTag < ApplicationRecord
+  belongs_to :memo
+  belongs_to :tag
+
+  validates :memo_id, uniqueness: { scope: :tag_id }
+end

--- a/backend/app/models/tag.rb
+++ b/backend/app/models/tag.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: tags
+#
+#  id               :bigint           not null, primary key
+#  color(色)        :integer          not null
+#  label(ラベル)    :string(30)       not null
+#  priority(優先度) :float(24)        not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+# Indexes
+#
+#  unique_index_label_on_tags  (label) UNIQUE
+#
+class Tag < ApplicationRecord
+  has_many :memo_tags, dependent: :destroy
+  has_many :memos, through: :memo_tags
+
+  validates :label, presence: true, uniqueness: true, length: { maximum: 30 }
+  validates :priority, presence: true
+  validates :color, presence: true
+
+  enum color: { white: 0, black: 10, red: 20, orange: 30, yellow: 40, green: 50, blue: 60, purple: 70 }
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -10,4 +10,6 @@
 #
 # NOTE: ログイン機能は当分は実装しないため、このモデルは当分は使用しない。
 class User < ApplicationRecord
+  validates :email, presence: true, length: { maximum: 30 }
+  validates :password, presence: true, length: { maximum: 30 }
 end

--- a/backend/config/locales/ja.yml
+++ b/backend/config/locales/ja.yml
@@ -6,6 +6,13 @@ ja:
         content: コンテンツ
       comment:
         content: 内容
+      tag:
+        label: ラベル
+        color: 色
+        priority: 優先度
+      memo_tag:
+        memo_id: メモ
+        tag_id: タグ
   errors:
     messages:
       blank: を入力してください

--- a/backend/db/Schemafile
+++ b/backend/db/Schemafile
@@ -1,12 +1,12 @@
 create_table 'users', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
-  t.string 'email', null: false, comment: 'ユーザーのEmailアドレス'
-  t.string 'password', null: false, comment: 'ユーザーのpassword'
+  t.string 'email', null: false, limit: 30, comment: 'ユーザーのEmailアドレス'
+  t.string 'password', null: false, limit: 30, comment: 'ユーザーのpassword'
   t.timestamp 'created_at', null: false
   t.timestamp 'updated_at', null: false
 end
 
 create_table 'memos', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
-  t.string 'title', null: false, comment: 'メモのタイトル'
+  t.string 'title', null: false, limit: 30, comment: 'メモのタイトル'
   t.text 'content', null: false, comment: 'メモの本文'
   t.timestamp 'created_at', null: false
   t.timestamp 'updated_at', null: false
@@ -21,3 +21,19 @@ create_table 'comments', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', fo
 end
 
 add_foreign_key 'comments', 'memos', column: 'memo_id', name: 'fk_comments_memo_id'
+
+create_table 'memo_tags', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
+  t.references :memo, null: false, foreign_key: { name: 'fk_memo_id_on_memo_tags' }, comment: 'メモID'
+  t.references :tag, null: false, foreign_key: { name: 'fk_tag_id_on_memo_tags' }, comment: 'タグID'
+  t.datetime "created_at", null: false
+  t.datetime "updated_at", null: false
+  t.index %w[memo_id tag_id], unique: true, name: "unique_index_memo_id_and_tag_id_on_memo_tags"
+end
+
+create_table 'tags', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
+  t.string :label, null: false, limit: 30, index: { unique: true, name: 'unique_index_label_on_tags' }, comment: 'ラベル'
+  t.integer :color, null: false, comment: '色'
+  t.float :priority, null: false, comment: '優先度'
+  t.datetime "created_at", null: false
+  t.datetime "updated_at", null: false
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -19,19 +19,40 @@ ActiveRecord::Schema[7.0].define(version: 0) do
     t.index ["memo_id"], name: "index_comments_on_memo_id"
   end
 
+  create_table "memo_tags", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "memo_id", null: false, comment: "メモID"
+    t.bigint "tag_id", null: false, comment: "タグID"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["memo_id", "tag_id"], name: "unique_index_memo_id_and_tag_id_on_memo_tags", unique: true
+    t.index ["memo_id"], name: "index_memo_tags_on_memo_id"
+    t.index ["tag_id"], name: "index_memo_tags_on_tag_id"
+  end
+
   create_table "memos", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "title", null: false, comment: "メモのタイトル"
+    t.string "title", limit: 30, null: false, comment: "メモのタイトル"
     t.text "content", null: false, comment: "メモの本文"
     t.timestamp "created_at", null: false
     t.timestamp "updated_at", null: false
   end
 
+  create_table "tags", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "label", limit: 30, null: false, comment: "ラベル"
+    t.integer "color", null: false, comment: "色"
+    t.float "priority", null: false, comment: "優先度"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["label"], name: "unique_index_label_on_tags", unique: true
+  end
+
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "email", null: false, comment: "ユーザーのEmailアドレス"
-    t.string "password", null: false, comment: "ユーザーのpassword"
+    t.string "email", limit: 30, null: false, comment: "ユーザーのEmailアドレス"
+    t.string "password", limit: 30, null: false, comment: "ユーザーのpassword"
     t.timestamp "created_at", null: false
     t.timestamp "updated_at", null: false
   end
 
   add_foreign_key "comments", "memos", name: "fk_comments_memo_id"
+  add_foreign_key "memo_tags", "memos", name: "fk_memo_id_on_memo_tags"
+  add_foreign_key "memo_tags", "tags", name: "fk_tag_id_on_memo_tags"
 end

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -18,11 +18,11 @@ require "faker"
     title: Faker::Lorem.sentence(word_count:10),
     content: Faker::Lorem.paragraphs(number: 5)
   )
-        
+
   10.times do |m|
     Comment.create!(
       memo_id: memo.id,
-      content:  Faker::Lorem.sentence(word_count:5)
-    )            
+      content: Faker::Lorem.sentence(word_count: 5)
+    )
   end
 end

--- a/backend/spec/factories/memo_tags.rb
+++ b/backend/spec/factories/memo_tags.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: memo_tags
+#
+#  id              :bigint           not null, primary key
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  memo_id(メモID) :bigint           not null
+#  tag_id(タグID)  :bigint           not null
+#
+# Indexes
+#
+#  index_memo_tags_on_memo_id                    (memo_id)
+#  index_memo_tags_on_tag_id                     (tag_id)
+#  unique_index_memo_id_and_tag_id_on_memo_tags  (memo_id,tag_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_memo_id_on_memo_tags  (memo_id => memos.id)
+#  fk_tag_id_on_memo_tags   (tag_id => tags.id)
+#
+FactoryBot.define do
+  factory :memo_tag do
+    memo
+    tag
+  end
+end

--- a/backend/spec/factories/memo_tags.rb
+++ b/backend/spec/factories/memo_tags.rb
@@ -23,7 +23,7 @@
 #
 FactoryBot.define do
   factory :memo_tag do
-    memo
-    tag
+    memo { association(:memo, strategy: :build, memo_tags: [instance]) }
+    tag { association(:tag, strategy: :build, memo_tags: [instance]) }
   end
 end

--- a/backend/spec/factories/tags.rb
+++ b/backend/spec/factories/tags.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: tags
+#
+#  id               :bigint           not null, primary key
+#  color(色)        :integer          not null
+#  label(ラベル)    :string(30)       not null
+#  priority(優先度) :float(24)        not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+# Indexes
+#
+#  unique_index_label_on_tags  (label) UNIQUE
+#
+FactoryBot.define do
+  factory :tag do
+    label { Faker::Lorem.sentence(word_count: 5) }
+    color { Tag.colors.values.sample }
+    priority { 0 }
+  end
+end

--- a/backend/spec/models/memo_spec.rb
+++ b/backend/spec/models/memo_spec.rb
@@ -11,64 +11,58 @@
 #  updated_at            :datetime         not null
 #
 RSpec.describe Memo do
-  subject(:memo) { build(:memo) }
-
   describe 'バリデーションのテスト' do
-    context 'title と content が有効な場合' do
-      it 'valid?メソッドがtrueを返すこと' do
+    let!(:memo) { build(:memo) }
+
+    context '属性が正常な場合' do
+      it 'trueを返す' do
         expect(memo).to be_valid
       end
     end
 
     context 'titleが空文字の場合' do
-      before { memo.title = '' }
-
-      it 'valid?メソッドがfalseを返すこと' do
-        expect(memo).not_to be_valid
+      before do
+        memo.title = ''
       end
 
-      it 'errorsに「タイトルを入力してください」と格納されること' do
-        memo.valid?
-        expect(memo.errors.full_messages).to eq ['タイトルを入力してください']
+      it 'falseを返し、errorが格納される' do
+        aggregate_failures do
+          expect(memo).not_to be_valid
+          expect(memo.errors.full_messages).to eq ['タイトルを入力してください']
+        end
       end
     end
 
     context 'titleがnilの場合' do
       before { memo.title = nil }
 
-      it 'valid?メソッドがfalseを返すこと' do
-        expect(memo).not_to be_valid
-      end
-
-      it 'errorsに「タイトルを入力してください」と格納されること' do
-        memo.valid?
-        expect(memo.errors.full_messages).to eq ['タイトルを入力してください']
+      it 'falseになり、errorが格納される' do
+        aggregate_failures do
+          expect(memo).not_to be_valid
+          expect(memo.errors.full_messages).to eq ['タイトルを入力してください']
+        end
       end
     end
 
     context 'contentが空文字の場合' do
       before { memo.content = '' }
 
-      it 'valid?メソッドがfalseを返すこと' do
-        expect(memo).not_to be_valid
-      end
-
-      it 'errorsに「コンテンツを入力してください」と格納されること' do
-        memo.valid?
-        expect(memo.errors.full_messages).to eq ['コンテンツを入力してください']
+      it 'falseが返り、errorsに「コンテンツを入力してください」と格納されること' do
+        aggregate_failures do
+          expect(memo).not_to be_valid
+          expect(memo.errors.full_messages).to eq ['コンテンツを入力してください']
+        end
       end
     end
 
     context 'contentがnilの場合' do
       before { memo.content = nil }
 
-      it 'valid?メソッドがfalseを返すこと' do
-        expect(memo).not_to be_valid
-      end
-
-      it 'errorsに「コンテンツを入力してください」と格納されること' do
-        memo.valid?
-        expect(memo.errors.full_messages).to eq ['コンテンツを入力してください']
+      it 'falseになり、errorsが格納されること' do
+        aggregate_failures do
+          expect(memo).not_to be_valid
+          expect(memo.errors.full_messages).to eq ['コンテンツを入力してください']
+        end
       end
     end
   end

--- a/backend/spec/models/memo_tag_spec.rb
+++ b/backend/spec/models/memo_tag_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: memo_tags
+#
+#  id              :bigint           not null, primary key
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  memo_id(メモID) :bigint           not null
+#  tag_id(タグID)  :bigint           not null
+#
+# Indexes
+#
+#  index_memo_tags_on_memo_id                    (memo_id)
+#  index_memo_tags_on_tag_id                     (tag_id)
+#  unique_index_memo_id_and_tag_id_on_memo_tags  (memo_id,tag_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_memo_id_on_memo_tags  (memo_id => memos.id)
+#  fk_tag_id_on_memo_tags   (tag_id => tags.id)
+#
+RSpec.describe MemoTag do
+  describe 'バリデーションのテスト' do
+    let!(:memo_tag) { build(:memo_tag) }
+
+    context '属性が正常な場合' do
+      it 'trueを返す' do
+        expect(memo_tag).to be_valid
+      end
+    end
+
+    context 'memo_idとtag_idが重複している場合' do
+      let(:already_exist_model) { create(:memo_tag) }
+      let(:model) do
+        build(
+          :memo_tag,
+          memo: already_exist_model.memo,
+          tag: already_exist_model.tag
+        )
+      end
+
+      it 'falseになり、errorsが格納される' do
+        aggregate_failures do
+          expect(model).not_to be_valid
+          expect(model.errors.full_messages).to eq ['メモはすでに存在します']
+        end
+      end
+    end
+  end
+end

--- a/backend/spec/models/tag_spec.rb
+++ b/backend/spec/models/tag_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: tags
+#
+#  id               :bigint           not null, primary key
+#  color(色)        :integer          not null
+#  label(ラベル)    :string(30)       not null
+#  priority(優先度) :float(24)        not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+# Indexes
+#
+#  unique_index_label_on_tags  (label) UNIQUE
+#
+RSpec.describe Tag do
+  describe 'バリデーションのテスト' do
+    let!(:tag) { build(:tag) }
+
+    context '属性が正常な場合' do
+      it 'trueを返す' do
+        expect(tag).to be_valid
+      end
+    end
+
+    context 'labelがnilの場合' do
+      before { tag.label = nil }
+
+      it 'falseになり、errorsが格納される' do
+        aggregate_failures do
+          expect(tag).not_to be_valid
+          expect(tag.errors.full_messages).to eq ['ラベルを入力してください']
+        end
+      end
+    end
+
+    context 'labelが31文字の場合' do
+      before { tag.label = Faker::Lorem.characters(number: 31) }
+
+      it 'falseになり、errorsが格納される' do
+        aggregate_failures do
+          expect(tag).not_to be_valid
+          expect(tag.errors.full_messages).to eq ['ラベルは30文字以内で入力してください']
+        end
+      end
+    end
+
+    context 'colorがnilの場合' do
+      before { tag.color = nil }
+
+      it 'falseになり、errorsが格納される' do
+        aggregate_failures do
+          expect(tag).not_to be_valid
+          expect(tag.errors.full_messages).to eq ['色を入力してください']
+        end
+      end
+    end
+
+    context 'priorityがnilの場合' do
+      before { tag.priority = nil }
+
+      it 'falseになり、errorsが格納される' do
+        aggregate_failures do
+          expect(tag).not_to be_valid
+          expect(tag.errors.full_messages).to eq ['優先度を入力してください']
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 対応するissue
<!-- ここに対応するissue番号を書く。issue番号が99なら、「- closes #99」と書く。 -->
- closes #29

## 対応内容
<!-- ここに対応した内容を書く。 -->
1. タグに関連する下記を実装
- タグテーブル、メモとタグの関連をもたせる中間テーブルの追加
- タグ、中間テーブルのモデル、バリデーション追加
- タグのテストを追加

2. その他の実装
- ユーザーテーブルとコメントテーブルのstringカラムでlimitを設定
- メモのテストをリファクタリング

## ER図
```mermaid
erDiagram
    users {
        string email PK "ユーザーのEmailアドレス"
        string password "ユーザーのpassword"
        timestamp created_at "作成日時"
        timestamp updated_at "更新日時"
    }

    memos {
        string title "メモのタイトル"
        text content "メモの本文"
        timestamp created_at "作成日時"
        timestamp updated_at "更新日時"
    }

    comments {
        bigint memo_id FK "メモID"
        string content "内容"
        timestamp created_at "作成日時"
        timestamp updated_at "更新日時"
    }

    memo_tags {
        bigint memo_id FK "メモID"
        bigint tag_id FK "タグID"
        timestamp created_at "作成日時"
        timestamp updated_at "更新日時"
    }

    tags {
        string label PK "ラベル"
        integer color "色"
        float priority "優先度"
        timestamp created_at "作成日時"
        timestamp updated_at "更新日時"
    }

    users ||--o{ memos : ""
    memos ||--o{ comments : ""
    memos ||--o{ memo_tags : ""
    tags ||--o{ memo_tags : ""
```