### PR TITLE
タグを単体で作成・更新するAPIを作成する

### DIFF
--- a/backend/app/controllers/tags_controller.rb
+++ b/backend/app/controllers/tags_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class TagsController < ApplicationController
+  # POST /tags
+  def create
+    tag = Tag.new(tag_params)
+    if tag.save
+      head :no_content
+    else
+      render json: { errors: tag.errors.full_messages }, status: :unprocessable_content
+    end
+  end
+
+  # PUT /tags/:id
+  def update
+    tag = Tag.find(params[:id])
+
+    if tag.update(update_tag_params)
+      head :no_content
+    else
+      render json: { errors: tag.errors.full_messages }, status: :unprocessable_content
+    end
+  end
+
+  private
+
+  def tag_params
+    params.require(:tag).permit(:label, :color, :priority)
+  end
+
+  def update_tag_params
+    params.require(:tag).permit(:label, :color, :priority)
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   resources :memos, only: %i[index show create update destroy] do
     resources :comments, only: %i[create]
   end
+  resources :tags, only: %i[create update]
 end

--- a/backend/spec/requests/tags_spec.rb
+++ b/backend/spec/requests/tags_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+RSpec.describe 'TagsController' do
+  describe 'POST /tags' do
+    context 'パラメーターが有効な場合' do
+      let(:valid_tag_params) { { label: Faker::Lorem.sentence(word_count: 5), color: :white, priority: 0 } }
+
+      it 'タグが追加され、204が返る' do
+        aggregate_failures do
+          expect do
+            post '/tags', params: valid_tag_params, as: :json
+          end.to change(Tag, :count).by(1)
+
+          expect(response).to have_http_status(:no_content)
+          expect(response.body).to be_empty
+        end
+      end
+    end
+
+    context 'パラメーターが無効な場合' do
+      let(:invalid_tag_params) { { label: '', color: :white, priority: 0 } }
+
+      it 'タグが追加されていないこと、422が返ることを確認する' do
+        aggregate_failures do
+          expect do
+            post '/tags', params: invalid_tag_params, as: :json
+          end.not_to change(Tag, :count)
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response.parsed_body['errors']).to eq(['ラベルを入力してください'])
+        end
+      end
+    end
+  end
+
+  describe 'PATCH /tags/:tag_id' do
+    context 'パラメーターが有効な場合' do
+      let!(:tag) { create(:tag) }
+      let(:valid_tag_params) { { label: Faker::Lorem.sentence(word_count: 5) } }
+
+      it 'タグが更新され、204が返る' do
+        aggregate_failures do
+          expect do
+            patch "/tags/#{tag.id}", params: valid_tag_params, as: :json
+          end.not_to change(Tag, :count)
+          expect(response).to have_http_status(:no_content)
+          expect(response.body).to be_empty
+        end
+      end
+    end
+
+    context 'パラメーターが無効な場合' do
+      let!(:tag) { create(:tag) }
+      let(:invalid_tag_params) { { label: Faker::Lorem.sentence(word_count: 31) } }
+
+      it 'タグが更新されていないこと、422が返ることを確認する' do
+        aggregate_failures do
+          expect do
+            patch "/tags/#{tag.id}", params: invalid_tag_params, as: :json
+          end.not_to change(Tag, :count)
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response.parsed_body['errors']).to eq(['ラベルは30文字以内で入力してください'])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 対応するissue
<!-- ここに対応するissue番号を書く。issue番号が99なら、「- closes #99」と書く。 -->
- closes #4 

## 対応内容
<!-- ここに対応した内容を書く。 -->
タグを単体で作成・更新するAPIとテストを作成しました。
