### PR TITLE
メモを論理削除できるようにする

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -36,6 +36,9 @@ gem 'ridgepole' # マイグレーションに使用するgem
 # Github: https://github.com/ruby-i18n/i18n
 gem 'rails-i18n' # i18n 日本語化対応用gem
 
+# Github: https://github.com/jhawthorn/discard
+gem 'discard' # 論理削除できるようにするgem
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
     diffy (3.4.2)
+    discard (1.4.0)
+      activerecord (>= 4.2, < 9.0)
     docile (1.4.0)
     drb (2.2.1)
     erubi (1.13.0)
@@ -301,6 +303,7 @@ DEPENDENCIES
   bootsnap
   committee-rails
   debug
+  discard
   factory_bot_rails
   faker
   jbuilder

--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -38,8 +38,11 @@ class MemosController < ApplicationController
   # DELETE /memos/:id
   def destroy
     memo = Memo.find(params[:id])
-    memo.destroy
-    head :no_content
+    if memo.discard
+      head :no_content
+    else
+      render json: { errors: memo.errors.full_messages }, status: :unprocessable_content
+    end
   end
 
   private

--- a/backend/app/models/memo.rb
+++ b/backend/app/models/memo.rb
@@ -6,11 +6,19 @@
 #
 #  id                    :bigint           not null, primary key
 #  content(メモの本文)   :text(65535)      not null
-#  title(メモのタイトル) :string(255)      not null
+#  discarded_at          :datetime
+#  title(メモのタイトル) :string(30)       not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #
+# Indexes
+#
+#  index_memos_on_discarded_at  (discarded_at)
+#
 class Memo < ApplicationRecord
+  include Discard::Model
+  default_scope -> { kept }
+
   has_many :comments, dependent: :destroy
   has_many :memo_tags, dependent: :destroy
   has_many :tags, through: :memo_tags

--- a/backend/db/Schemafile
+++ b/backend/db/Schemafile
@@ -10,6 +10,8 @@ create_table 'memos', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force
   t.text 'content', null: false, comment: 'メモの本文'
   t.timestamp 'created_at', null: false
   t.timestamp 'updated_at', null: false
+  t.datetime "discarded_at"
+  t.index ["discarded_at"], name: "index_memos_on_discarded_at"
 end
 
 create_table 'comments', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 0) do
+ActiveRecord::Schema[7.2].define(version: 0) do
   create_table "comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "memo_id", null: false, comment: "メモID"
     t.string "content", limit: 1024, null: false, comment: "内容"
@@ -34,6 +34,8 @@ ActiveRecord::Schema[7.0].define(version: 0) do
     t.text "content", null: false, comment: "メモの本文"
     t.timestamp "created_at", null: false
     t.timestamp "updated_at", null: false
+    t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_memos_on_discarded_at"
   end
 
   create_table "tags", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/backend/doc/components/memoSchema.yml
+++ b/backend/doc/components/memoSchema.yml
@@ -21,6 +21,11 @@ components:
           type: string
           format: date-time
           example: 2021-01-01T00:00:00.000Z
+        discarded_at:
+          type: string
+          format: date-time
+          nullable: true
+          example: null
         comments:
           type: array
           items:

--- a/backend/spec/factories/memos.rb
+++ b/backend/spec/factories/memos.rb
@@ -5,10 +5,15 @@
 # Table name: memos
 #
 #  id                    :bigint           not null, primary key
-#  content(メモの本文)   :string(255)      not null
-#  title(メモのタイトル) :string(255)      not null
+#  content(メモの本文)   :text(65535)      not null
+#  discarded_at          :datetime
+#  title(メモのタイトル) :string(30)       not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
+#
+# Indexes
+#
+#  index_memos_on_discarded_at  (discarded_at)
 #
 FactoryBot.define do
   factory :memo do

--- a/backend/spec/models/memo_spec.rb
+++ b/backend/spec/models/memo_spec.rb
@@ -6,9 +6,14 @@
 #
 #  id                    :bigint           not null, primary key
 #  content(メモの本文)   :text(65535)      not null
-#  title(メモのタイトル) :string(255)      not null
+#  discarded_at          :datetime
+#  title(メモのタイトル) :string(30)       not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
+#
+# Indexes
+#
+#  index_memos_on_discarded_at  (discarded_at)
 #
 RSpec.describe Memo do
   describe 'バリデーションのテスト' do

--- a/backend/spec/requests/memos_spec.rb
+++ b/backend/spec/requests/memos_spec.rb
@@ -133,9 +133,13 @@ RSpec.describe 'MemosController' do
     context 'メモを削除しようとした場合' do
       let!(:existing_memo) { create(:memo) }
 
-      it 'メモを削除されたことを確認する' do
+      it 'メモが論理削除されたことを確認する' do
         aggregate_failures do
-          expect { delete "/memos/#{existing_memo.id}" }.to change(Memo, :count).by(-1)
+          # 論理削除のためメモの総数が変わっていないことを確認する
+          expect { delete "/memos/#{existing_memo.id}" }.not_to change(Memo.with_discarded, :count)
+          existing_memo.reload
+          expect(existing_memo.discarded?).to be true
+          expect(existing_memo.discarded_at).not_to be_nil
           assert_request_schema_confirm
           expect(response).to have_http_status(:no_content)
           assert_response_schema_confirm(204)

--- a/backend/test/fixtures/memos.yml
+++ b/backend/test/fixtures/memos.yml
@@ -3,10 +3,15 @@
 # Table name: memos
 #
 #  id                    :bigint           not null, primary key
-#  content(メモの本文)   :string(255)      not null
-#  title(メモのタイトル) :string(255)      not null
+#  content(メモの本文)   :text(65535)      not null
+#  discarded_at          :datetime
+#  title(メモのタイトル) :string(30)       not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
+#
+# Indexes
+#
+#  index_memos_on_discarded_at  (discarded_at)
 #
 
 one:


### PR DESCRIPTION
## 対応するissue
<!-- ここに対応するissue番号を書く。issue番号が99なら、「- closes #99」と書く。 -->
- closes #16

## 対応内容
<!-- ここに対応した内容を書く。 -->
メモを論理削除できるようにしました。
gem の discard を使っています。
 
ref:
https://qiita.com/piggydev/items/05e7276ed0cada69da76
https://qiita.com/piggydev/items/05e7276ed0cada69da76

