### PR TITLE
メモのタグをメモの作成に登録できるようにする

### DIFF
--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -16,11 +16,11 @@ class MemosController < ApplicationController
 
   # POST /memos
   def create
-    memo = Memo.new(memo_params)
-    if memo.save
+    form = Memo::CreateForm.build(memo_params)
+    if form.save
       head :no_content
     else
-      render json: { messages: memo.errors.full_messages }, status: :unprocessable_content
+      render json: { messages: form.errors.full_messages }, status: :unprocessable_content
     end
   end
 
@@ -45,7 +45,8 @@ class MemosController < ApplicationController
   private
 
   def memo_params
-    params.require(:memo).permit(:title, :content)
+    # e.g. params: { memo: { title: 'タイトル', content: 'メモ', tags: [{ tag_id: 1},] } }
+    params.require(:memo).permit(:title, :content, tags: [{}])
   end
 
   def update_memo_params

--- a/backend/app/models/memo/create_form.rb
+++ b/backend/app/models/memo/create_form.rb
@@ -62,10 +62,12 @@ class Memo
       )
     end
 
+    def tags
+      Tag.where(id: (@params[:tags] || []).pluck(:tag_id))
+    end
+
     def build_memo_tags
-      tag_ids = @params[:tags]&.map { |tag| tag[:tag_id] } || []
-      tags = Tag.where(id: tag_ids)
-      @memo_tags = tags.map { |tag| MemoTag.new(memo: @memo, tag: tag) }
+      tags.map { |tag| MemoTag.new(memo: @memo, tag: tag) }
     end
   end
 end

--- a/backend/app/models/memo/create_form.rb
+++ b/backend/app/models/memo/create_form.rb
@@ -11,6 +11,11 @@ class Memo
     validates :memo, cascade: true
     validates :memo_tags, cascade: true
 
+    # @param params [ActionController::Parameters] Controller側でpermitしたパラメータ
+    #   @option params [String] :title メモのタイトル
+    #   @option params [String] :content メモの本文
+    #   @option params [Array<Hash>] :tags 紐付けるタグの情報
+    #     @option tags [Integer] :tag_id タグのID
     # @return [Memo::CreateForm]
     def self.build(params)
       new(params).tap(&:setup)

--- a/backend/app/models/memo/create_form.rb
+++ b/backend/app/models/memo/create_form.rb
@@ -67,7 +67,7 @@ class Memo
     end
 
     def build_memo_tags
-      tags.map { |tag| MemoTag.new(memo: @memo, tag: tag) }
+      @memo_tags = tags.map { |tag| MemoTag.new(memo: @memo, tag: tag) }
     end
   end
 end

--- a/backend/app/models/memo/create_form.rb
+++ b/backend/app/models/memo/create_form.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class Memo
+  class CreateForm
+    # indent
+    # https://github.com/rubocop/ruby-style-guide?tab=readme-ov-file#empty-lines-around-bodies
+    include ActiveModel::Validations
+    attr_reader :memo, :memo_tags
+
+    validates :memo, cascade: true
+    validates :memo_tags, cascade: true
+
+    # @return [Memo::CreateForm]
+    def self.build(params)
+      new(params).tap(&:setup)
+    end
+
+    # e.g. params = { memo: { title: 'memo', content: 'メモ',tags: [{tag_id:1},] } }
+    def initialize(params)
+      @params = params
+    end
+
+    def setup
+      build_memo
+      build_memo_tags
+    end
+
+    def save
+      return false unless valid?
+      ActiveRecord::Base.transaction do
+        @memo.save!
+        @memo_tags.each(&:save!)
+      end
+      true
+    rescue ActiveRecord::RecordInvalid => e
+      errors.add(:base, e.message)
+      false
+    end
+
+    private
+
+    def build_memo
+      @memo = Memo.new(
+        title: @params[:title],
+        content: @params[:content]
+      )
+    end
+
+    def build_memo_tags
+      tag_ids = @params[:tags]&.map { |tag| tag[:tag_id] } || []
+      tags = Tag.where(id: tag_ids)
+      @memo_tags = tags.map { |tag| MemoTag.new(memo: @memo, tag: tag) }
+    end
+  end
+end

--- a/backend/app/models/memo/create_form.rb
+++ b/backend/app/models/memo/create_form.rb
@@ -5,6 +5,7 @@ class Memo
     # indent
     # https://github.com/rubocop/ruby-style-guide?tab=readme-ov-file#empty-lines-around-bodies
     include ActiveModel::Validations
+
     attr_reader :memo, :memo_tags
 
     validates :memo, cascade: true
@@ -27,6 +28,7 @@ class Memo
 
     def save
       return false unless valid?
+
       ActiveRecord::Base.transaction do
         @memo.save!
         @memo_tags.each(&:save!)

--- a/backend/config/locales/ja.yml
+++ b/backend/config/locales/ja.yml
@@ -13,6 +13,12 @@ ja:
       memo_tag:
         memo_id: メモ
         tag_id: タグ
+  activemodel:
+    attributes:
+      memo/create_form:
+        memo: メモ
+        memo_tags: メモのタグ
   errors:
     messages:
       blank: を入力してください
+      invalid_association: の%{association}

--- a/backend/spec/models/memo/create_form_spec.rb
+++ b/backend/spec/models/memo/create_form_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+RSpec.describe Memo::CreateForm do
+  describe '::build(params:)' do
+    let!(:tags) do
+      {
+        '1' => create(:tag),
+        '2' => create(:tag)
+      }
+    end
+
+    # paramsの準備(データの定義)
+    let(:params) do
+      {
+        title: 'memo',
+        content: 'メモ',
+        tags: [
+          { tag_id: tags['1'].id },
+          { tag_id: tags['2'].id }
+        ]
+      }
+    end
+
+    it '返り値がMemo::CreateFormで、メモとメモタグがbuildされること' do
+      aggregate_failures do
+        result = described_class.build(params)
+
+        # 返り値の検証:
+        expect(result.class).to eq(described_class)
+
+        # メモがbuildされたことの検証:
+        expect(result.memo.class).to eq(Memo)
+        expect(result.memo.title).to eq(params[:title])
+        expect(result.memo.content).to eq(params[:content])
+
+        # メモのタグがbuildされたことの検証:
+        expect(result.memo_tags.class).to eq(Array)
+        result.memo_tags.each do |memo_tag|
+          expect(memo_tag.class).to eq(MemoTag)
+        end
+      end
+    end
+  end
+
+  describe '#save' do
+    # paramsの準備(データの定義)
+    let(:params) do
+      {
+        title: 'memo',
+        content: 'メモ',
+        tags: [
+          { tag_id: tags['1'].id },
+          { tag_id: tags['2'].id }
+        ]
+      }
+    end
+    let!(:tags) do
+      {
+        '1' => create(:tag),
+        '2' => create(:tag)
+      }
+    end
+
+    context 'バリデーションエラーになる時' do
+      let!(:tags) do
+        {
+          '1' => create(:tag),
+          '2' => create(:tag)
+        }
+      end
+
+      # paramsの準備(データの定義)
+      let(:params) do
+        {
+          title: '',
+          content: '',
+          tags: [
+            { tag_id: tags['1'].id },
+            { tag_id: tags['2'].id }
+          ]
+        }
+      end
+
+      it 'メモとメモタグが保存されないこと' do
+        aggregate_failures do
+          form = described_class.build(params)
+          expect(form.save).to be_falsey
+        end
+      end
+    end
+
+    it 'メモとメモタグが保存されること' do
+      aggregate_failures do
+        form = described_class.build(params)
+
+        # 返り値の検証:
+        expect(form.save).to be_truthy
+
+        # メモがbuildされたことの検証:
+        created_memo = Memo.find_by(title: params[:title], content: params[:content])
+        expect(created_memo).to be_present
+
+        # メモのタグがbuildされたことの検証
+        params[:tags].each do |tag|
+          memo_tag = MemoTag.find_by(memo_id: created_memo.id, tag_id: tag[:tag_id])
+          expect(memo_tag).to be_present
+        end
+      end
+    end
+  end
+end

--- a/backend/spec/requests/memos_spec.rb
+++ b/backend/spec/requests/memos_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'MemosController' do
           assert_request_schema_confirm
           expect(response).to have_http_status(:unprocessable_content)
           assert_response_schema_confirm(422)
-          expect(response.parsed_body['messages']).to eq(%w[タイトルを入力してください コンテンツを入力してください])
+          expect(response.parsed_body['messages']).to eq(['メモのタイトルを入力してください、コンテンツを入力してください'])
         end
       end
     end


### PR DESCRIPTION
## 対応するissue
- closes #1 
(このPRでは、Createのみ対応しています)
## 対応内容
- Memo作成時に、関連するTagとの関連付けを示すMemoTagテーブルにレコード作成するよう修正。
- MemoクラスのインナークラスとしてCreateFormを作成し、
複数モデルに関連するデータ操作の責務を、FormObjectに逃しつつ実装しました。

 
