### PR TITLE
updateメソッドをFormObjectに移行する

### DIFF
--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -25,13 +25,19 @@ class MemosController < ApplicationController
   end
 
   # PUT /memos/:id
+  # レスポンスが違うって、ことはコントローラーそうに問題がありそう
+  # 最短でデバッグできてそうかを考える
+  # エラーを確認した際に、バリデーションエラーがあったら、その項目を触っている触っている箇所を確認しよう
   def update
-    memo = Memo.find(params[:id])
-
-    if memo.update(update_memo_params)
-      head :no_content
+    form = Memo::UpdateForm.build(update_memo_params, params[:id])
+    if form.save
+      head(:no_content)
     else
-      render json: { messages: memo.errors.full_messages }, status: :unprocessable_content
+      render(
+        json: { messages: form.errors.full_messages },
+        # ググる
+        status: :unprocessable_entity
+      )
     end
   end
 

--- a/backend/app/models/memo/update_form.rb
+++ b/backend/app/models/memo/update_form.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+class Memo
+  class UpdateForm
+    include ActiveModel::Validations
+
+    attr_accessor :memo
+
+    validates :memo, cascade: true
+
+    # @param params [ActionController::Parameters] Controller側でpermitしたパラメータ
+    #   @option params [String] :content メモの本文
+    # @return [Memo::UpdateForm]
+    def self.build(params,id)
+      new(params, id).tap(&:setup)
+    end
+
+    # e.g. params = { memo: { id: 1, content: 'メモ更新' } }
+    def initialize(params,id)
+      @params = params
+      @id = id
+    end
+
+    def setup
+      @memo = Memo.find(@id)
+      unless @params[:content].nil?
+        @memo.content = @params[:content]
+      end
+    end
+
+    # @return [Boolean] 保存に成功したかどうか
+    def save
+      if valid?
+        @memo.save
+      else
+        false
+      end
+    end
+  end
+end

--- a/backend/config/locales/ja.yml
+++ b/backend/config/locales/ja.yml
@@ -18,6 +18,8 @@ ja:
       memo/create_form:
         memo: メモ
         memo_tags: メモのタグ
+      memo/update_form:
+        memo: メモ
   errors:
     messages:
       blank: を入力してください

--- a/backend/spec/requests/memos_spec.rb
+++ b/backend/spec/requests/memos_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe 'MemosController' do
           existing_memo.reload
           expect(response).to have_http_status(:unprocessable_content)
           assert_response_schema_confirm(422)
-          expect(response.parsed_body['messages']).to eq(['コンテンツを入力してください'])
+          expect(response.parsed_body['messages']).to eq(['メモのコンテンツを入力してください'])
         end
       end
     end


### PR DESCRIPTION
## 対応するissue
- closes #1

## 対応内容
- 既存動作のFormObjectへの移行
- テストの微修正
